### PR TITLE
fix XRC warnings in wxWidgets 3.2.0

### DIFF
--- a/dialogs/about.wxg
+++ b/dialogs/about.wxg
@@ -30,7 +30,6 @@
                         <object class="wxBoxSizer" name="sizer_5" base="EditBoxSizer">
                             <orient>wxHORIZONTAL</orient>
                             <object class="sizeritem">
-                                <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                 <border>0</border>
                                 <option>1</option>
                                 <object class="wxStaticText" name="AboutProductNameLabel" base="EditStaticText">
@@ -55,7 +54,6 @@
                         <object class="wxBoxSizer" name="AboutProductSizer" base="EditBoxSizer">
                             <orient>wxHORIZONTAL</orient>
                             <object class="sizeritem">
-                                <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                 <border>0</border>
                                 <option>1</option>
                                 <object class="wxStaticText" name="AboutProductDescriptionLabel" base="EditStaticText">
@@ -80,7 +78,6 @@
                         <object class="wxBoxSizer" name="AboutMessageSizer" base="EditBoxSizer">
                             <orient>wxHORIZONTAL</orient>
                             <object class="sizeritem">
-                                <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                 <border>0</border>
                                 <option>2</option>
                                 <object class="wxStaticText" name="AboutMessageLabel" base="EditStaticText">

--- a/dialogs/audiocontrols.wxg
+++ b/dialogs/audiocontrols.wxg
@@ -14,7 +14,7 @@
                     <orient>wxVERTICAL</orient>
                     <label>Mixer</label>
                     <object class="sizeritem">
-                        <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <flag>wxEXPAND</flag>
                         <border>0</border>
                         <option>1</option>
                         <object class="wxPanel" name="AudioChannelPanel" base="EditPanel">
@@ -22,7 +22,7 @@
                             <object class="wxBoxSizer" name="AudioChannelSizer" base="EditBoxSizer">
                                 <orient>wxHORIZONTAL</orient>
                                 <object class="sizeritem">
-                                    <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                    <flag>wxALIGN_CENTER_VERTICAL</flag>
                                     <border>0</border>
                                     <option>1</option>
                                     <object class="wxStaticText" name="NoAudioText" base="EditStaticText">
@@ -58,7 +58,7 @@
                         <object class="wxBoxSizer" name="SoundIOLabelSizer" base="EditBoxSizer">
                             <orient>wxVERTICAL</orient>
                             <object class="sizeritem">
-                                <flag>wxLEFT|wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxLEFT|wxRIGHT</flag>
                                 <border>5</border>
                                 <option>1</option>
                                 <object class="wxStaticText" name="MidiInLabel" base="EditStaticText">
@@ -68,7 +68,7 @@
                                 </object>
                             </object>
                             <object class="sizeritem">
-                                <flag>wxLEFT|wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxLEFT|wxRIGHT</flag>
                                 <border>5</border>
                                 <option>1</option>
                                 <object class="wxStaticText" name="MidiOutLabel" base="EditStaticText">
@@ -78,7 +78,7 @@
                                 </object>
                             </object>
                             <object class="sizeritem">
-                                <flag>wxLEFT|wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxLEFT|wxRIGHT</flag>
                                 <border>5</border>
                                 <option>1</option>
                                 <object class="wxStaticText" name="SoundInLabel" base="EditStaticText">
@@ -151,7 +151,6 @@
                                 <object class="wxBoxSizer" name="sizer_1" base="EditBoxSizer">
                                     <orient>wxVERTICAL</orient>
                                     <object class="sizeritem">
-                                        <flag>wxALIGN_CENTER_VERTICAL</flag>
                                         <border>0</border>
                                         <option>1</option>
                                         <object class="wxStaticText" name="MidiInFileLabel" base="EditStaticText">
@@ -161,7 +160,6 @@
                                         </object>
                                     </object>
                                     <object class="sizeritem">
-                                        <flag>wxALIGN_CENTER_VERTICAL</flag>
                                         <border>0</border>
                                         <option>1</option>
                                         <object class="wxStaticText" name="MidiOutFileLabel" base="EditStaticText">
@@ -171,7 +169,6 @@
                                         </object>
                                     </object>
                                     <object class="sizeritem">
-                                        <flag>wxALIGN_CENTER_VERTICAL</flag>
                                         <border>0</border>
                                         <option>1</option>
                                         <object class="wxStaticText" name="SampleInFileLabel" base="EditStaticText">

--- a/dialogs/catapult.wxg
+++ b/dialogs/catapult.wxg
@@ -8,7 +8,7 @@
         <object class="wxBoxSizer" name="TopSizer" base="EditBoxSizer">
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
-                <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxEXPAND</flag>
                 <border>0</border>
                 <option>1</option>
                 <object class="wxPanel" name="MainWindowPanel" base="EditPanel">
@@ -49,7 +49,7 @@
                                     <object class="wxBoxSizer" name="PowerLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="PowerLed" base="EditStaticBitmap">
@@ -58,7 +58,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="PowerLedLabel" base="EditStaticText">
@@ -75,7 +75,7 @@
                                     <object class="wxBoxSizer" name="CapsLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="CapsLockLed" base="EditStaticBitmap">
@@ -84,7 +84,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="CapsLockLedLabel" base="EditStaticText">
@@ -102,7 +102,7 @@
                                     <object class="wxBoxSizer" name="KanaLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="KanaLed" base="EditStaticBitmap">
@@ -111,7 +111,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="KanaLedLabel" base="EditStaticText">
@@ -128,7 +128,7 @@
                                     <object class="wxBoxSizer" name="PauseLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="PauseLed" base="EditStaticBitmap">
@@ -137,7 +137,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="PauseLedLabel" base="EditStaticText">
@@ -154,7 +154,7 @@
                                     <object class="wxBoxSizer" name="TurboLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="TurboLed" base="EditStaticBitmap">
@@ -163,7 +163,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="TurboLedLabel" base="EditStaticText">
@@ -180,7 +180,7 @@
                                     <object class="wxBoxSizer" name="FDDLedSizer" base="EditBoxSizer">
                                         <orient>wxVERTICAL</orient>
                                         <object class="sizeritem">
-                                            <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>0</border>
                                             <option>0</option>
                                             <object class="wxStaticBitmap" name="FDDLed" base="EditStaticBitmap">
@@ -189,7 +189,7 @@
                                             </object>
                                         </object>
                                         <object class="sizeritem">
-                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                            <flag>wxTOP|wxALIGN_CENTER_HORIZONTAL</flag>
                                             <border>2</border>
                                             <option>0</option>
                                             <object class="wxStaticText" name="FDDLedLabel" base="EditStaticText">

--- a/dialogs/checkconfigs.wxg
+++ b/dialogs/checkconfigs.wxg
@@ -191,7 +191,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>10</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="ButtonSizer" base="EditBoxSizer">

--- a/dialogs/config.wxg
+++ b/dialogs/config.wxg
@@ -87,7 +87,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxEXPAND|wxALIGN_RIGHT</flag>
+                <flag>wxEXPAND</flag>
                 <border>0</border>
                 <option>1</option>
                 <object class="wxBoxSizer" name="sizer_9" base="EditBoxSizer">

--- a/dialogs/fullscreen.wxg
+++ b/dialogs/fullscreen.wxg
@@ -9,13 +9,13 @@
         <object class="wxBoxSizer" name="sizer_1" base="EditBoxSizer">
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
-                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>10</border>
                 <option>1</option>
                 <object class="wxBoxSizer" name="TextSizer" base="EditBoxSizer">
                     <orient>wxHORIZONTAL</orient>
                     <object class="sizeritem">
-                        <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <flag>wxALIGN_CENTER_VERTICAL</flag>
                         <border>0</border>
                         <option>1</option>
                         <object class="wxStaticText" name="label_1" base="EditStaticText">
@@ -34,7 +34,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>10</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="ButtonSizer" base="EditBoxSizer">

--- a/dialogs/ipsselect.wxg
+++ b/dialogs/ipsselect.wxg
@@ -69,7 +69,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxRIGHT|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxRIGHT|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>5</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="ButtonSizer" base="EditBoxSizer">

--- a/dialogs/misccontrols.wxg
+++ b/dialogs/misccontrols.wxg
@@ -309,7 +309,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxALL|wxEXPAND|wxALIGN_RIGHT|wxALIGN_CENTER_HORIZONTAL</flag>
+                <flag>wxALL|wxEXPAND</flag>
                 <border>5</border>
                 <option>0</option>
                 <object class="wxStaticBoxSizer" name="sizer_2" base="EditStaticBoxSizer">

--- a/dialogs/romtype.wxg
+++ b/dialogs/romtype.wxg
@@ -28,7 +28,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxRIGHT|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxRIGHT|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>5</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="ButtonSizer" base="EditBoxSizer">

--- a/dialogs/screenshot.wxg
+++ b/dialogs/screenshot.wxg
@@ -9,13 +9,13 @@
         <object class="wxBoxSizer" name="sizer_1" base="EditBoxSizer">
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
-                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>10</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="TextSizer" base="EditBoxSizer">
                     <orient>wxHORIZONTAL</orient>
                     <object class="sizeritem">
-                        <flag>wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                        <flag>wxALIGN_CENTER_VERTICAL</flag>
                         <border>0</border>
                         <option>1</option>
                         <object class="wxStaticText" name="label_1" base="EditStaticText">
@@ -34,7 +34,7 @@
                 </object>
             </object>
             <object class="sizeritem">
-                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL</flag>
                 <border>10</border>
                 <option>0</option>
                 <object class="wxBoxSizer" name="ButtonSizer" base="EditBoxSizer">

--- a/dialogs/session.wxg
+++ b/dialogs/session.wxg
@@ -371,7 +371,7 @@
                                                         </object>
                                                     </object>
                                                     <object class="sizeritem">
-                                                        <flag>wxLEFT|wxRIGHT|wxALIGN_CENTER_HORIZONTAL</flag>
+                                                        <flag>wxLEFT|wxRIGHT</flag>
                                                         <border>3</border>
                                                         <option>0</option>
                                                         <object class="wxButton" name="RewindButton" base="EditButton">

--- a/dialogs/videocontrols.wxg
+++ b/dialogs/videocontrols.wxg
@@ -41,6 +41,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
+                                                <flag>wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>0</border>
                                                 <option>0</option>
                                                 <object class="wxComboBox" name="RendererSelector" base="EditComboBox">
@@ -70,7 +71,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxTOP|wxBOTTOM</flag>
+                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxToggleButton" name="DeInterlaceButton" base="EditToggleButton">

--- a/dialogs/videocontrols.wxg
+++ b/dialogs/videocontrols.wxg
@@ -20,7 +20,7 @@
                         <object class="wxBoxSizer" name="VideoSwitchSizer" base="EditBoxSizer">
                             <orient>wxHORIZONTAL</orient>
                             <object class="sizeritem">
-                                <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxEXPAND</flag>
                                 <border>0</border>
                                 <option>0</option>
                                 <object class="wxBoxSizer" name="sizer_18" base="EditBoxSizer">
@@ -41,7 +41,6 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>0</border>
                                                 <option>0</option>
                                                 <object class="wxComboBox" name="RendererSelector" base="EditComboBox">
@@ -71,7 +70,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxTOP|wxBOTTOM</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxToggleButton" name="DeInterlaceButton" base="EditToggleButton">
@@ -84,7 +83,7 @@
                                 </object>
                             </object>
                             <object class="sizeritem">
-                                <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxEXPAND</flag>
                                 <border>0</border>
                                 <option>0</option>
                                 <object class="wxBoxSizer" name="sizer_22" base="EditBoxSizer">
@@ -105,13 +104,13 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxEXPAND</flag>
                                                 <border>5</border>
                                                 <option>1</option>
                                                 <object class="wxBoxSizer" name="ScalerComboSizer" base="EditBoxSizer">
                                                     <orient>wxHORIZONTAL</orient>
                                                     <object class="sizeritem">
-                                                        <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                        <flag>wxEXPAND</flag>
                                                         <border>0</border>
                                                         <option>1</option>
                                                         <object class="wxBoxSizer" name="sizer_8" base="EditBoxSizer">
@@ -173,7 +172,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxToggleButton" name="LimitSpriteButton" base="EditToggleButton">
@@ -186,7 +185,7 @@
                                 </object>
                             </object>
                             <object class="sizeritem">
-                                <flag>wxEXPAND|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                <flag>wxEXPAND</flag>
                                 <border>0</border>
                                 <option>0</option>
                                 <object class="wxBoxSizer" name="sizer_27" base="EditBoxSizer">
@@ -233,7 +232,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxToggleButton" name="FullScreenButton" base="EditToggleButton">
@@ -246,19 +245,18 @@
                                 </object>
                             </object>
                             <object class="sizeritem">
-                                <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                 <border>0</border>
                                 <option>0</option>
                                 <object class="wxBoxSizer" name="sizer_6" base="EditBoxSizer">
                                     <orient>wxVERTICAL</orient>
                                     <object class="sizeritem">
-                                        <flag>wxALIGN_BOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                        <flag>wxALIGN_CENTER_HORIZONTAL</flag>
                                         <border>0</border>
                                         <option>1</option>
                                         <object class="wxBoxSizer" name="sizer_28_copy" base="EditBoxSizer">
                                             <orient>wxHORIZONTAL</orient>
                                             <object class="sizeritem">
-                                                <flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxStaticText" name="VideoSourceLabel" base="EditStaticText">
@@ -297,7 +295,7 @@
                                                 </object>
                                             </object>
                                             <object class="sizeritem">
-                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+                                                <flag>wxTOP|wxBOTTOM|wxALIGN_CENTER_VERTICAL</flag>
                                                 <border>5</border>
                                                 <option>0</option>
                                                 <object class="wxToggleButton" name="DisableSpritesButton" base="EditToggleButton">


### PR DESCRIPTION
When compiling Catapult using newest wxWidgets (3.2.0), it results in lots of warnings being displayed on startup (and when opening other dialogs afterwards), I believe this is due to this change:

> Using invalid flags with wxBoxSizer or wxGridSizer items now triggers asserts
  when done from the code or error messages when done in XRC. These asserts are
  best avoided by fixing the flags, but wxSizerFlags::DisableConsistencyChecks()
  can be used to globally suppress them until this can be done. Even less
  intrusively, environment variable WXSUPPRESS_SIZER_FLAGS_CHECK can be set (to
  any value) to achieve the same effect.

(from https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.0/docs/changes.txt )

The aforementioned workaround with the environment variable didn't work for me on Linux.

The warnings are like so (I removed duplicates):
```
18:14:17: XRC error: 40: vertical alignment flag "wxALIGN_CENTER_VERTICAL" has no effect inside a vertical box sizer, remove it and consider inserting a spacer instead
18:14:17: XRC error: 305: horizontal alignment flag "wxALIGN_CENTER_HORIZONTAL" has no effect inside a horizontal box sizer, remove it and consider inserting a spacer instead
18:14:17: XRC error: 11: "wxEXPAND" is incompatible with horizontal alignment flag ""wxALIGN_CENTER_HORIZONTAL"" in a vertical box sizer
18:14:17: XRC error: 20: "wxEXPAND" is incompatible with vertical alignment flag ""wxALIGN_CENTER_VERTICAL"" in a horizontal box sizer
18:14:17: XRC error: 279: both "wxALIGN_RIGHT" and "wxALIGN_CENTER_HORIZONTAL" specify horizontal alignment and can't be used together
```

I removed the flags that the warning claim to have no effect, for wxEXPAND errors I opted to leave wxEXPAND instead of the other flags although I'm not sure what is intended (after fixing I noticed a change in how the main window behaves when resized, but I think the behaviour after the patch is reasonable).

I'm not overly familiar with wxWidgets so I might have missed something, but after this patch no errors seem to appear. Not sure about any other incompatibilities with 3.2.0 (the link lists some others) but it seems that other than the warnings, Catapult works just fine.

